### PR TITLE
Resolve alt text import

### DIFF
--- a/classes/wordml2xhtmlpass1.xsl
+++ b/classes/wordml2xhtmlpass1.xsl
@@ -4776,7 +4776,7 @@
         <xsl:when test="$img_hyperlink != ''">
             <!-- The image is linked -->
             <a href="{$img_hyperlink}">
-                <img src="{$img_src}" id="{$img_id}" name="{$img_basefilename}" alt="{$img_alt}" longdesc="{$img_longdesc}">
+                <img src="{$img_src}" id="{$img_id}" name="{$img_basefilename}" alt="{$img_alt}" >
                     <xsl:if test="$img_width != ''">
                         <xsl:attribute name="width">
                             <xsl:value-of select="$img_width"/>
@@ -4790,7 +4790,7 @@
         </xsl:when>
         <xsl:otherwise>
             <!-- The image is not linked -->
-            <img src="{$img_src}" id="{$img_id}" name="{$img_basefilename}" alt="{$img_alt}" longdesc="{$img_longdesc}">
+            <img src="{$img_src}" id="{$img_id}" name="{$img_basefilename}" alt="{$img_alt}" >
                 <xsl:if test="$img_width != ''">
                     <xsl:attribute name="width">
                         <xsl:value-of select="$img_width"/>

--- a/classes/wordml2xhtmlpass1.xsl
+++ b/classes/wordml2xhtmlpass1.xsl
@@ -4717,8 +4717,11 @@
             <xsl:with-param name="condition" select="$debug_flag = '2' and $img_hyperlink_rid != ''"/>
         </xsl:call-template>
 
-        <!-- Map title field to alt attribute -->
-        <xsl:variable name="img_alt" select="wp:inline/wp:docPr/@title"/>
+        <!-- Map title field to alt attribute (REMOVED) -->
+        <!-- <xsl:variable name="img_alt" select="wp:inline/wp:docPr/@title"/> -->
+
+        <!-- Map description field to alt attribute -->
+        <xsl:variable name="img_alt" select="wp:inline/wp:docPr/@descr"/>
         <!-- The wp:extent/@cx and @cy attributes define the size of the image. They are denominated in
              EMUs (English Metric Units); 1 inch = 914400, therefore 1 pixel = 914400 / 96 (dpi) = 9525
              cf. http://polymathprogrammer.com/2009/10/22/english-metric-units-and-open-xml/ -->
@@ -4726,8 +4729,9 @@
         <xsl:variable name="img_width" select="substring-before(wp:inline/wp:extent/@cx div 9525, '.')"/>
         <xsl:variable name="img_height" select="substring-before(wp:inline/wp:extent/@cy div 9525, '.')"/>
 
-        <!-- Map description field to longdesc attribute -->
-        <xsl:variable name="img_longdesc" select="wp:inline/wp:docPr/@descr"/>
+        <!-- Map description field to longdesc attribute (REMOVED)-->
+        <!-- <xsl:variable name="img_longdesc" select="wp:inline/wp:docPr/@descr"/> -->
+
         <!-- Map name field to id attribute: it contains a sequence number for the image, e.g. "Picture 1" -->
         <xsl:variable name="img_id" select="translate(wp:inline/wp:docPr/@name, ' ', '')"/>
         <!-- Store the internal file name in the class attribute, for want of a better place

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023021700;              // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version = 2024112200;              // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires = 2020061500;               // Requires Moodle 3.9 or higher.
 $plugin->component = 'booktool_wordimport';   // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.4.12 (Build: 2023021700)'; // Human readable version information.
+$plugin->release = '1.4.13 (Build: 2024112200)'; // Human readable version information.
 $plugin->dependencies = array('booktool_importhtml' => 2016052300);

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024112200;              // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version = 2024112201;              // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires = 2020061500;               // Requires Moodle 3.9 or higher.
 $plugin->component = 'booktool_wordimport';   // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.4.13 (Build: 2024112200)'; // Human readable version information.
+$plugin->release = '1.4.13 (Build: 2024112201)'; // Human readable version information.
 $plugin->dependencies = array('booktool_importhtml' => 2016052300);


### PR DESCRIPTION
Updated wordml2xhtmlpass1.xsl to map alt text to the alt attribute instead of the deprecated longdesc attribute.